### PR TITLE
fix: support caching of implicit transform dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "brfs": "^1.0.1",
+    "node-lessify": "0.0.11",
     "proxyquire": "^1.7.0",
     "split": "~0.3.0",
     "tape": "^2.12.3",


### PR DESCRIPTION
This adds caching of the `emit(file, ...)` API of watchify, which is
used by transforms that implicitly require other files, such as those
used for LESS compilation.

Fixes: https://github.com/benbria/uber-watchify/issues/8